### PR TITLE
Gracefully fail authentication with error messages

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -141,7 +141,13 @@ class AuthController extends Controller
      */
     public function login(LoginRequest $request): JsonResponse
     {
-        $user = User::where('email', $request->email)->first();
+        try {
+            $user = User::where('email', $request->email)->firstOrFail();
+        } catch (\Exception $e) {
+            throw ValidationException::withMessages([
+                'email' => [__('The provided credentials are incorrect.')],
+            ]);
+        }
 
         $request->authenticate($user);
 


### PR DESCRIPTION
return a generic error rather than `No query results for model`