### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ "main" ]
     paths:
+    - '.github/workflows/laravel.yml'
     - 'app/**'
     - 'config/**'
     - 'tests/**'
@@ -13,6 +14,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
+    - '.github/workflows/laravel.yml'
     - 'app/**'
     - 'config/**'
     - 'tests/**'

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Laravel
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/k2so-dev/laravel-nuxt/security/code-scanning/2](https://github.com/k2so-dev/laravel-nuxt/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless they have their own `permissions` key. Based on the actions and steps in the workflow, the job primarily interacts with the repository's contents (e.g., reading files, installing dependencies, running tests). Therefore, we can set `contents: read` as the minimal required permission.

The `permissions` block should be added at the top of the workflow file, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
