### PR TITLE
Wrap SPA auth endpoints with 'web' middleware so session cookies persist

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -10,16 +10,19 @@ Route::get('/', function () {
 });
 
 Route::prefix('api/v1')->group(function () {
-    Route::get('login/{provider}/redirect', [AuthController::class, 'redirect'])->name('login.provider.redirect');
-    Route::get('login/{provider}/callback', [AuthController::class, 'callback'])->middleware(['web'])->name('login.provider.callback');
-    Route::post('login', [AuthController::class, 'login'])->middleware(['throttle:login'])->name('login');
-    Route::post('register', [AuthController::class, 'register'])->name('register');
-    Route::post('forgot-password', [AuthController::class, 'sendResetPasswordLink'])->middleware('throttle:5,1')->name('password.email');
-    Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('password.store');
-    Route::post('verification-notification', [AuthController::class, 'verificationNotification'])->middleware('throttle:verification-notification')->name('verification.send');
-    Route::get('verify-email/{ulid}/{hash}', [AuthController::class, 'verifyEmail'])->middleware(['signed', 'throttle:6,1'])->name('verification.verify');
 
-    Route::middleware(["auth:" . config('auth.defaults.guard')])->group(function () {
+    Route::middleware('web')->group(function () {
+        Route::get('login/{provider}/redirect', [AuthController::class, 'redirect'])->name('login.provider.redirect');
+        Route::get('login/{provider}/callback', [AuthController::class, 'callback'])->middleware(['web'])->name('login.provider.callback');
+        Route::post('login', [AuthController::class, 'login'])->middleware(['throttle:login'])->name('login');
+        Route::post('register', [AuthController::class, 'register'])->name('register');
+        Route::post('forgot-password', [AuthController::class, 'sendResetPasswordLink'])->middleware('throttle:5,1')->name('password.email');
+        Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('password.store');
+        Route::post('verification-notification', [AuthController::class, 'verificationNotification'])->middleware('throttle:verification-notification')->name('verification.send');
+        Route::get('verify-email/{ulid}/{hash}', [AuthController::class, 'verifyEmail'])->middleware(['signed', 'throttle:6,1'])->name('verification.verify');
+    });
+
+    Route::middleware(['web', "auth:" . config('auth.defaults.guard')])->group(function () {
         Route::post('logout', [AuthController::class, 'logout'])->name('logout');
         Route::post('devices/disconnect', [AuthController::class, 'deviceDisconnect'])->name('devices.disconnect');
         Route::get('devices', [AuthController::class, 'devices'])->name('devices');


### PR DESCRIPTION
Problem
- SPA auth endpoints were registered under API routes without the 'web' middleware. Session middleware was not applied, so login didn't persist authentication.

Fix
- Wrap SPA auth endpoints (login, register, social callbacks, password, verification) in Route::middleware('web')->group(...).

Verification
- Reproduced login flow locally; session and auth persisted and /api/v1/user returns authenticated user.

